### PR TITLE
fix: Remove unnecessary CSS from smart-webcomponents

### DIFF
--- a/src/QueryBuilder.tsx
+++ b/src/QueryBuilder.tsx
@@ -2,9 +2,11 @@ import React, { useRef, useEffect } from 'react';
 import { QueryBuilder, QueryBuilderProps } from 'smart-webcomponents-react/querybuilder';
 import { useTheme2 } from '@grafana/ui';
 
-import 'smart-webcomponents-react/source/styles/smart.default.css';
 import 'smart-webcomponents-react/source/styles/smart.dark-orange.css';
 import 'smart-webcomponents-react/source/styles/smart.orange.css';
+import 'smart-webcomponents-react/source/styles/components/smart.base.css';
+import 'smart-webcomponents-react/source/styles/components/smart.common.css';
+import 'smart-webcomponents-react/source/styles/components/smart.querybuilder.css';
 
 type TestResultsQueryBuilderProps = Omit<QueryBuilderProps, 'customOperations' | 'fields' | 'messages' | 'showIcons'> &
   React.HTMLAttributes<Element> & {


### PR DESCRIPTION
`smart.default.css` brings in the styling needed for all smart-webcomponents and is responsible for the majority of the bundle size when packaging the plugin. With some trial and error, I was able to figure out the minimum set of files needed to get the query builder functional. This takes the bundle size down from 4.3MB to 2MB.