### PR TITLE
feat: Add notebook priority to execution

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -17,7 +17,14 @@ import {
   toUtc,
 } from '@grafana/data';
 import { getBackendSrv, getTemplateSrv, FetchError } from '@grafana/runtime';
-import { NotebookQuery, NotebookDataSourceOptions, defaultQuery, Notebook, Execution } from './types';
+import {
+  NotebookQuery,
+  NotebookDataSourceOptions,
+  defaultQuery,
+  Notebook,
+  Execution,
+  ExecutionPriority,
+} from './types';
 import { timeout } from './utils';
 
 import { NotebookVariableSupport } from 'variables';
@@ -165,7 +172,9 @@ export class DataSource extends DataSourceApi<NotebookQuery, NotebookDataSourceO
       const response = await getBackendSrv().datasourceRequest({
         url: this.url + '/ninbexecution/v1/executions',
         method: 'POST',
-        data: [{ notebookId, workspaceId, parameters, resultCachePeriod: cacheTimeout }],
+        data: [
+          { notebookId, workspaceId, parameters, resultCachePeriod: cacheTimeout, priority: ExecutionPriority.MEDIUM },
+        ],
       });
 
       return this.handleNotebookExecution(response.data.executions[0].id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,12 @@ export interface Execution {
   cachedResult: boolean;
 }
 
+export enum ExecutionPriority {
+  MEDIUM = 'MEDIUM',
+  LOW = 'LOW',
+  HIGH = 'HIGH',
+}
+
 export interface Parameter {
   id: string;
   display_name: string;


### PR DESCRIPTION
Recent changes to the notebook execution service added the concept of an execution's "priority". We want executions from dashboards to be "medium" priority. This change adds the new field to the request to queue an execution.

https://dev.azure.com/ni/DevCentral/_workitems/edit/2341585

I successfully tested this locally pointing to the main-test cluster.