### PR TITLE
fix: Query for max # of notebooks (1000)

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -205,7 +205,7 @@ export class DataSource extends DataSourceApi<NotebookQuery, NotebookDataSourceO
   async queryNotebooks(path: string): Promise<Notebook[]> {
     const filter = `name.Contains("${path}") && type == "Notebook"`;
     try {
-      const response = await getBackendSrv().post(this.url + '/niapp/v1/webapps/query', { filter });
+      const response = await getBackendSrv().post(this.url + '/niapp/v1/webapps/query', { filter, take: 1000 });
       return response.webapps as Notebook[];
     } catch (e) {
       throw new Error(


### PR DESCRIPTION
https://dev.azure.com/ni/DevCentral/_workitems/edit/2333281

By default, the `webapps/query` route only returns 100 items. We have more notebooks than that on main-test, so it wasn't possible to see some of them. This change increases the take to 1000 to make it less likely that this will be a problem.

Note that this is just a quick band-aid. We should be re-querying when the user types in the notebook combo box, but that will take a bit more effort.