### PR TITLE
fix: users can access all notebooks in notebook drop-down selector

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -28,7 +28,7 @@ type State = {
 };
 
 export class QueryEditor extends PureComponent<Props, State> {
-  notebookMetadata: Record<string, NotebookWithMetadata> = {};
+  notebookMetadata: Record<string, Notebook> = {};
 
   constructor(props: Props) {
     super(props);
@@ -47,7 +47,10 @@ export class QueryEditor extends PureComponent<Props, State> {
   loadNotebookOptions = _.debounce((query: string, cb?: LoadOptionsCallback<string>) => {
     this.props.datasource
       .queryNotebooks(query)  
-      .then((notebooks) => cb?.(notebooks.map(formatNotebookOption)))
+      .then((notebooks) => {
+        notebooks.forEach(notebook => this.notebookMetadata[notebook.id] = notebook);
+        cb?.(notebooks.map(formatNotebookOption));
+      })
       .catch(this.handleError);
   }, 300);
 

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -57,7 +57,7 @@ export class QueryEditor extends PureComponent<Props, State> {
   async componentDidMount() {
     try {
       if (this.props.query.id) {
-        const notebook = this.getNotebook(this.props.query.id);
+        const notebook = await this.props.datasource.getNotebook(this.props.query.id);
         if (notebook) {
           await this.populateNotebookMetadata(notebook);
         }
@@ -249,7 +249,6 @@ export class QueryEditor extends PureComponent<Props, State> {
             placeholder="Select notebook"
             menuPlacement="bottom"
             maxMenuHeight={200}
-            width={30}
             value={selectedNotebook ? formatNotebookOption(selectedNotebook) : undefined}
           />
         </Field>

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -3,9 +3,8 @@
  * when editing a Grafana panel.
  */
 import _ from 'lodash';
-import pickBy from 'lodash/pickBy';
 import React, { PureComponent } from 'react';
-import { Alert, Field, Input, Select, Label, IconButton, TextArea, LoadingPlaceholder, AsyncSelect, LoadOptionsCallback, InlineField } from '@grafana/ui';
+import { Alert, Field, Input, Select, Label, IconButton, TextArea, LoadingPlaceholder, AsyncSelect, LoadOptionsCallback } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { DataSource } from './datasource';
@@ -45,7 +44,7 @@ export class QueryEditor extends PureComponent<Props, State> {
     this.setState({ queryError: error });
   }
 
-  loadTableOptions = _.debounce((query: string, cb?: LoadOptionsCallback<string>) => {
+  loadNotebookOptions = _.debounce((query: string, cb?: LoadOptionsCallback<string>) => {
     this.props.datasource
       .queryNotebooks(query)  
       .then((notebooks) => cb?.(notebooks.map(formatNotebookOption)))
@@ -99,7 +98,7 @@ export class QueryEditor extends PureComponent<Props, State> {
 
     // Preseve matching parameter values
     const oldNotebook = this.getNotebook(query.id);
-    const parameters = pickBy(query.parameters, (value: any, id: string) => {
+    const parameters = _.pickBy(query.parameters, (value: any, id: string) => {
       const newParam = notebook.metadata.parameters.find((param: any) => param.id === id);
       if (!newParam) {
         return false;
@@ -239,19 +238,17 @@ export class QueryEditor extends PureComponent<Props, State> {
     return (
       <div className="sl-notebook-query-editor">
         <Field label="Notebook" className="sl-notebook-selector">
-          <InlineField label="Notebook">
-            <AsyncSelect
-              cacheOptions={false}
-              defaultOptions
-              loadOptions={this.loadTableOptions}
-              onChange={this.onNotebookChange}
-              placeholder="Select notebook"
-              menuPlacement="bottom"
-              maxMenuHeight={200}
-              width={30}
-              value={selectedNotebook ? formatNotebookOption(selectedNotebook) : undefined}
-            />
-          </InlineField>
+          <AsyncSelect
+            cacheOptions={false}
+            defaultOptions
+            loadOptions={this.loadNotebookOptions}
+            onChange={this.onNotebookChange}
+            placeholder="Select notebook"
+            menuPlacement="bottom"
+            maxMenuHeight={200}
+            width={30}
+            value={selectedNotebook ? formatNotebookOption(selectedNotebook) : undefined}
+          />
         </Field>
         {notebookMetaLoaded && !this.state.loadingMetadata && (
           <>

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -205,7 +205,7 @@ export class DataSource extends DataSourceApi<NotebookQuery, NotebookDataSourceO
   async queryNotebooks(path: string): Promise<Notebook[]> {
     const filter = `name.Contains("${path}") && type == "Notebook"`;
     try {
-      const response = await getBackendSrv().post(this.url + '/niapp/v1/webapps/query', { filter, take: 1000 });
+      const response = await getBackendSrv().post(this.url + '/niapp/v1/webapps/query', { filter, take: 5 });
       return response.webapps as Notebook[];
     } catch (e) {
       throw new Error(

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -216,6 +216,19 @@ export class DataSource extends DataSourceApi<NotebookQuery, NotebookDataSourceO
     }
   }
 
+  async getNotebook(id: string): Promise<Notebook> {
+    try {
+      const response = await getBackendSrv().get(this.url + `/niapp/v1/webapps/${id}`);
+      return response as Notebook;
+    } catch (e) {
+      throw new Error(
+        `The query for SystemLink notebooks failed with error ${(e as FetchError).status}: ${
+          (e as FetchError).statusText
+        }.`
+      );
+    }
+  }
+
   async getNotebookMetadata(id: string): Promise<{ metadata: any; parameters: any }> {
     let response;
     try {


### PR DESCRIPTION
**Justification:** The drop-down selector for the notebook datasource in Grafana only displays a limited number of notebooks (currently hard-coded to be 1000). We only query once, so if there are more than 1000 notebooks, the user wouldn't be able to access the rest of the notebooks. Therefore, we should re-query for the notebooks as the user types in a filter. 

**Implementation:** The Select component was replaced with an AsyncSelect component to implement the new dynamic filtering behavior. The __.debounce_ function was also implemented, which allows for some buffer time as the user types before a new query is made. These changes were made in reference to the dataframe datasource as the two work very similarly. However, in the code for the notebook datasource, the _loadTableOptions_ and _handleLoadOptions_ functions were combined, and a separate function was created for error handling (_handleError_). Additionally, the combobox only displays five notebooks at a time, although this can easily be changed to display more notebooks if requested.

**Testing:** The web dev tools were used to test this change. The payload was checked to see if a new query was made every time the user typed something in the filter. 